### PR TITLE
fix variable save_order_url -> saveOrderURL

### DIFF
--- a/gateways/manual/script.js
+++ b/gateways/manual/script.js
@@ -20,7 +20,7 @@
             };
 
             jQuery.ajax({
-                url: ShoppingCart.settings.baseURL + ShoppingCart.settings.urls.save_order_url + '/task:pay',
+                url: ShoppingCart.settings.baseURL + ShoppingCart.settings.urls.saveOrderURL + '/task:pay',
                 data: order,
                 type: 'POST'
             })


### PR DESCRIPTION
on shoppingcart-manual-checkout script.js file have a wrong variable on line 23 
missing "save_order_url" change to "saveOrderURL"